### PR TITLE
Make driver compatible with kernel before 6.6.0

### DIFF
--- a/xr_usb_serial_common.c
+++ b/xr_usb_serial_common.c
@@ -752,8 +752,13 @@ static void xr_usb_serial_tty_close(struct tty_struct *tty, struct file *filp)
 	tty_port_close(&xr_usb_serial->port, tty, filp);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
 static ssize_t xr_usb_serial_tty_write(struct tty_struct *tty,
 					const unsigned char *buf, size_t count)
+#else
+static int xr_usb_serial_tty_write(struct tty_struct *tty,
+					const unsigned char *buf, int count)
+#endif
 {
 	struct xr_usb_serial *xr_usb_serial = tty->driver_data;
 	int stat;


### PR DESCRIPTION
- The prototype of xr_usb_serial_tty_write was changed in 6.6.0 Add conditional compilation to make it compatible with older kernels